### PR TITLE
pip install, gitignore, optional dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,127 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+

--- a/heimdall/scripts/view_container.py
+++ b/heimdall/scripts/view_container.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse
-from heimdall import view_container
+from .. import view_container
 
 
 def tobool(inp):
@@ -21,7 +21,13 @@ parser.add_argument('--load_into_memory', type=tobool, default='n',
 parser.add_argument('--n_threads', type=int, default=1,
                     help='number of threads used by z5py')
 
-args = parser.parse_args()
-view_container(args.path, args.ndim,
-               args.exclude_names, args.include_names,
-               args.load_into_memory, args.n_threads)
+
+def main():
+    args = parser.parse_args()
+    view_container(args.path, args.ndim,
+                   args.exclude_names, args.include_names,
+                   args.load_into_memory, args.n_threads)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,30 @@
 import runpy
-from setuptools import setup
+import itertools
+from setuptools import setup, find_packages
 
 __version__ = runpy.run_path('heimdall/version.py')['__version__']
-setup(name='heimdall',
-      version=__version__,
-      author='Constantin Pape',
-      url='https://github.com/constantinpape/heimdall',
-      license='MIT',
-      scripts='scrips/view_contanier')
+
+requires = [
+    "napari",
+    "numpy",
+]
+
+extras = {
+    "hdf5": ["h5py"],
+}
+
+extras["all"] = list(itertools.chain.from_iterable(extras.values()))
+
+setup(
+    name='heimdall',
+    packages=find_packages(include='heimdall'),
+    version=__version__,
+    author='Constantin Pape',
+    install_requires=requires,
+    extras_require=extras,
+    url='https://github.com/constantinpape/heimdall',
+    license='MIT',
+    entry_points={
+        "console_scripts": ["view_container = heimdall.scripts.view_container:main"]
+    },
+)


### PR DESCRIPTION
I had a multi-dataset N5 volume to view and was excited to not have to try to figure out Fiji again.

- pip install works
- view_container is accessible in a more standard way, through console_scripts
- gitignore ignores most of what it needs to
- (speculative) not-very-scalable implementation of optional dependencies

These are just the changes I made quickly to try it out locally, feel free to use any which interest you and ditch any which don't.

Haven't actually been able to test them because I can't figure out how to get my python environment to recognise my modern Qt installation.